### PR TITLE
Add Fast menu with message editing functionality

### DIFF
--- a/client/src/components/message-fast-menu.ts
+++ b/client/src/components/message-fast-menu.ts
@@ -1,18 +1,38 @@
 import Controller from '../lib/controller';
-import MessageFastMenuView from '../views/message-fast-menu-view';
+import { appStore } from '../store/app-store';
+import { PersonalMessage } from '../types/entities';
+import { RenderedPersonalMessage } from '../views/chats-main-content-view';
+import MessageFastMenuView, { ReplyOrEdit } from '../views/message-fast-menu-view';
 
 class MessageFastMenu extends Controller<MessageFastMenuView> {
-  constructor($root: HTMLElement) {
-    super(new MessageFastMenuView($root));
+  constructor($container: HTMLElement, $message: HTMLLIElement, message: RenderedPersonalMessage) {
+    const getReplyOrEdit = (message: RenderedPersonalMessage): ReplyOrEdit => {
+      if (!appStore.user) {
+        return 'edit';
+      }
+      if (message.userId === appStore.user.id) {
+        return 'edit';
+      } else {
+        return 'reply';
+      }
+    };
+    super(new MessageFastMenuView($container, $message, message, getReplyOrEdit(message)));
   }
 
   async init(): Promise<void> {
     this.view.render();
+    this.view.bindShowEditForm(MessageFastMenu.showEditForm);
   }
 
   destroy(): void {
     this.view.getRootElement().innerHTML = '';
   }
+
+  static showEditForm = ($message: HTMLLIElement): void => {};
+
+  static bindShowEditForm = (handler: ($message: HTMLLIElement) => void): void => {
+    MessageFastMenu.showEditForm = handler;
+  };
 }
 
 export default MessageFastMenu;

--- a/client/src/develop/data.ts
+++ b/client/src/develop/data.ts
@@ -47,7 +47,8 @@ export const personalMessages: PersonalMessage[] = [
     toUserId: '2',
     message: moment().subtract(6, 'days').calendar(),
     date: moment().subtract(6, 'days').unix(),
-    responseMessageId: null,
+    responsedToMessageId: null,
+    responsedToMessage: null,
   },
   {
     id: '2',
@@ -55,7 +56,8 @@ export const personalMessages: PersonalMessage[] = [
     toUserId: '2',
     message: 'Yo man!',
     date: moment().subtract(6, 'days').unix(),
-    responseMessageId: null,
+    responsedToMessageId: null,
+    responsedToMessage: null,
   },
   {
     id: '3',
@@ -63,7 +65,8 @@ export const personalMessages: PersonalMessage[] = [
     toUserId: '1',
     message: 'Yo Yo!',
     date: moment().subtract(4, 'days').unix(),
-    responseMessageId: '2',
+    responsedToMessageId: '2',
+    responsedToMessage: null,
   },
   {
     id: '4',
@@ -71,7 +74,8 @@ export const personalMessages: PersonalMessage[] = [
     toUserId: '3',
     message: 'Yo User 3!',
     date: moment().subtract(2, 'days').unix(),
-    responseMessageId: null,
+    responsedToMessageId: null,
+    responsedToMessage: null,
   },
   {
     id: '5',
@@ -79,7 +83,8 @@ export const personalMessages: PersonalMessage[] = [
     toUserId: '2',
     message: 'Yo Yo Yo User 2!',
     date: moment().subtract(4, 'days').unix(),
-    responseMessageId: '4',
+    responsedToMessageId: '4',
+    responsedToMessage: null,
   },
   {
     id: '6',
@@ -87,7 +92,8 @@ export const personalMessages: PersonalMessage[] = [
     toUserId: '2',
     message: 'How is it going User 2',
     date: moment().subtract(4, 'days').unix(),
-    responseMessageId: null,
+    responsedToMessageId: null,
+    responsedToMessage: null,
   },
 ];
 

--- a/client/src/lib/http.ts
+++ b/client/src/lib/http.ts
@@ -94,6 +94,10 @@ class Http {
     return this.http.put<T, R>(url, data, config);
   }
 
+  patch<T = unknown, R = AxiosResponse<T>>(url: string, data?: T, config?: AxiosRequestConfig): Promise<R> {
+    return this.http.patch<T, R>(url, data, config);
+  }
+
   delete<T = unknown, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R> {
     return this.http.delete<T, R>(url, config);
   }

--- a/client/src/types/entities.ts
+++ b/client/src/types/entities.ts
@@ -26,9 +26,10 @@ export interface FetchedUser {
 export interface PersonalMessage extends MongoEntity {
   fromUserId: MongoObjectId;
   toUserId: MongoObjectId;
-  responseMessageId: MongoObjectId | null;
+  responsedToMessageId: MongoObjectId | null;
   date: Timestamp;
   message: string;
+  responsedToMessage: PersonalMessage | null;
 }
 
 export interface ChannelMessage extends MongoEntity {

--- a/client/src/views/chats-main-content-view.ts
+++ b/client/src/views/chats-main-content-view.ts
@@ -1,14 +1,16 @@
 import View from '../lib/view';
-import { Chat, MongoObjectId } from '../types/entities';
-import { $, isClosestElementOfCssClass } from '../utils/functions';
+import { Chat, MongoObjectId, PersonalMessage } from '../types/entities';
+import { $, isClosestElementOfCssClass, isElementOfCssClass } from '../utils/functions';
 import MainView from './main-view';
 import * as userIcon from '../assets/icons/discord.svg';
 
 export type RenderedPersonalMessage = {
   id: MongoObjectId;
+  userId: MongoObjectId;
   username: string;
   date: string;
   message: string;
+  responsedToMessage: RenderedPersonalMessage | null;
 };
 
 class ChatsMainContentView extends View {
@@ -20,7 +22,17 @@ class ChatsMainContentView extends View {
   chat: Chat | null;
   $chatInput: HTMLInputElement;
   $messageList: HTMLUListElement;
-  messagesMap: Map<HTMLLIElement, { $fastMenu: HTMLDivElement; $menu: HTMLDivElement }>;
+  messagesMap: Map<
+    HTMLLIElement,
+    {
+      $fastMenu: HTMLDivElement;
+      $menu: HTMLDivElement;
+      $editFormContainer: HTMLDivElement;
+      $messageContent: HTMLElement;
+      message: RenderedPersonalMessage;
+    }
+  >;
+  editedMessageContent: string;
 
   constructor(chat: Chat | null) {
     const $root = MainView.$mainContent;
@@ -32,6 +44,7 @@ class ChatsMainContentView extends View {
     this.$chatInput = $('input', 'chat__input');
     this.$messageList = $('ul', 'chat__messages-list');
     this.messagesMap = new Map();
+    this.editedMessageContent = '';
   }
 
   build(): void {
@@ -42,21 +55,27 @@ class ChatsMainContentView extends View {
       const messages: RenderedPersonalMessage[] = [
         {
           id: '01',
+          userId: '03',
           username: 'Hlib Hodovaniuk',
           date: '01/26/2023 9:44 AM',
           message: 'Hello',
+          responsedToMessage: null,
         },
         {
           id: '02',
+          userId: '03',
           username: 'Alexander Chornyi',
           date: '01/26/2023 9:45 AM',
           message: 'Hi',
+          responsedToMessage: null,
         },
         {
           id: '01',
+          userId: '03',
           username: 'Hlib Hodovaniuk',
           date: '01/26/2023 9:47 AM',
           message: 'How do you do?',
+          responsedToMessage: null,
         },
       ];
 
@@ -90,19 +109,30 @@ class ChatsMainContentView extends View {
     });
   };
 
-  createMessageItem({ id, username, message, date }: RenderedPersonalMessage): HTMLLIElement {
+  editMessageContent($message: HTMLLIElement, message: RenderedPersonalMessage): void {
+    const items = this.messagesMap.get($message);
+    if (!items) {
+      return;
+    }
+    items.$messageContent.textContent = message.message;
+    items.message = message;
+  }
+
+  createMessageItem(message_: RenderedPersonalMessage): HTMLLIElement {
+    const { id, username, message, date } = message_;
     const $item = $('li', ['chat__messages-list-item', 'personal-message']);
     const $userIconBlock = $('div', 'personal-message__icon-block');
     const $userIcon = $('img', 'personal-message__icon');
     $userIcon.src = userIcon.default;
 
-    const $massagesBlock = $('div', 'personal-message__massages-block');
+    const $messagesBlock = $('div', 'personal-message__massages-block');
     const $info = $('div', 'personal-message__info');
     const $userName = $('span', 'personal-message__name');
     const $spaceFake = $('span', 'personal-message__space');
     const $messageDate = $('span', 'personal-message__date');
     const $message = $('p', 'personal-message__message');
     const $fastMenu = $('div', 'chat__fast-menu');
+    const $editFormContainer = $('div', 'personal-message__edit-form-container');
     const $menu = $('div', 'chat__menu');
 
     $userName.textContent = `${username}`;
@@ -112,10 +142,10 @@ class ChatsMainContentView extends View {
 
     $userIconBlock.append($userIcon);
     $info.append($userName, $spaceFake, $messageDate);
-    $massagesBlock.append($info, $message);
-    $item.append($userIconBlock, $massagesBlock, $fastMenu, $menu);
+    $messagesBlock.append($info, $message);
+    $item.append($userIconBlock, $messagesBlock, $editFormContainer, $fastMenu, $menu);
 
-    this.messagesMap.set($item, { $fastMenu, $menu });
+    this.messagesMap.set($item, { $fastMenu, $menu, $editFormContainer, $messageContent: $message, message: message_ });
 
     return $item;
   }
@@ -124,24 +154,129 @@ class ChatsMainContentView extends View {
     this.$chatInput.value = '';
   }
 
-  bindMessageHover = (handler: ($root: HTMLElement) => Promise<void>): void => {
-    this.$messageList.onmouseover = async (event) => {
-      if (isClosestElementOfCssClass<HTMLLIElement>(event.target, 'personal-message')) {
-        const data = this.messagesMap.get(event.target);
-        if (data) {
-          await handler(data.$fastMenu);
+  bindMessageHover = (
+    displayFastMenuHandler: (
+      $container: HTMLElement,
+      $message: HTMLLIElement,
+      message: RenderedPersonalMessage
+    ) => Promise<void>
+  ): void => {
+    this.$messageList.onmouseover = async (mouseOverEvent) => {
+      if (isClosestElementOfCssClass<HTMLLIElement>(mouseOverEvent.target, 'personal-message')) {
+        if (!mouseOverEvent.target.classList.contains('personal-message_edit')) {
+          const data = this.messagesMap.get(mouseOverEvent.target);
+          if (data) {
+            await displayFastMenuHandler(data.$fastMenu, mouseOverEvent.target, data.message);
+            mouseOverEvent.target.onmouseleave = () => {
+              this.destroyFastMenu(data.$fastMenu);
+            };
+          }
         }
-
-        event.target.onmouseleave = this.onMessageLeave;
       }
     };
   };
 
-  bindMessageLeave = (handler: ($root: HTMLElement) => void): void => {
-    // this.onMessageLeave = handler;
+  bindDestroyFastMenu = (destroyFastMenuHandler: ($fastMenuContainer: HTMLElement) => void): void => {
+    this.destroyFastMenu = destroyFastMenuHandler;
   };
 
-  onMessageLeave = (): void => {};
+  destroyFastMenu = ($fastMenuContainer: HTMLElement): void => {};
+
+  createEditMessageForm($message: HTMLLIElement, message: RenderedPersonalMessage): HTMLFormElement {
+    const $form = $('form', 'personal-message__edit-form');
+    const $messageContainer = $('div', 'personal-message__edit-form-container');
+    const $messageInput = $('input', 'personal-message__edit-form-input');
+    const $messageIdInput = $('input');
+    const $controlsContainer = $('div', 'personal-message__edit-form-controls');
+    const $cancelControl = $('button', 'personal-message__edit-form-cancel');
+    const $saveControl = $('button', 'personal-message__edit-form-save');
+
+    $messageInput.name = 'message';
+    $messageInput.value = message.message;
+
+    $messageIdInput.name = 'id';
+    $messageIdInput.type = 'hidden';
+    $messageIdInput.value = message.id;
+
+    $saveControl.type = 'submit';
+    $saveControl.textContent = 'save';
+
+    $cancelControl.type = 'button';
+    $cancelControl.textContent = 'cancel';
+
+    $messageContainer.append($messageInput);
+    $controlsContainer.append('escape to ', $cancelControl, ' • enter to ', $saveControl);
+    $form.append($messageContainer, $controlsContainer, $messageIdInput);
+
+    $form.onsubmit = async (event) => {
+      event.preventDefault();
+      await this.onEditMessageFormSubmit(new FormData($form), $message);
+      this.destroyEditMessageForm($message);
+    };
+
+    $cancelControl.onclick = () => {
+      this.destroyEditMessageForm($message);
+    };
+
+    return $form;
+  }
+
+  displayEditMessageForm = ($message: HTMLLIElement): void => {
+    const items = this.messagesMap.get($message);
+    if (!items) {
+      return;
+    }
+    const $form = this.createEditMessageForm($message, items.message);
+    items.$editFormContainer.innerHTML = '';
+    items.$editFormContainer.append($form);
+    this.destroyFastMenu(items.$fastMenu);
+    this.destroyOtherEditMessageForms($message);
+    $message.classList.add('personal-message_edit');
+    this.bindFormHotKeys($message, $form);
+  };
+
+  destroyEditMessageForm($message: HTMLLIElement): void {
+    const items = this.messagesMap.get($message);
+    if (!items) {
+      return;
+    }
+    items.$editFormContainer.innerHTML = '';
+    $message.classList.remove('personal-message_edit');
+    this.resetFormHotKeys();
+  }
+
+  destroyOtherEditMessageForms($message: HTMLLIElement): void {
+    this.messagesMap.forEach((_, $item) => {
+      if ($message !== $item) {
+        this.destroyEditMessageForm($item);
+      }
+    });
+  }
+
+  onEditMessageFormSubmit = async (formData: FormData, $message: HTMLLIElement): Promise<void> => {};
+
+  bindEditMessageFormSubmit = (handler: (formData: FormData, $message: HTMLLIElement) => Promise<void>): void => {
+    this.onEditMessageFormSubmit = handler;
+  };
+
+  setEditedMessageContent = (content: string): void => {
+    this.editedMessageContent = content;
+  };
+
+  bindFormHotKeys = ($message: HTMLLIElement, $form: HTMLFormElement): void => {
+    window.onkeyup = (event) => {
+      if (event.key === 'Escape') {
+        this.destroyEditMessageForm($message);
+      } else if (event.key === 'Enter') {
+        console.log('enter');
+        $form.submit();
+      }
+    };
+  };
+
+  resetFormHotKeys = () => {
+    window.onkeyup = null;
+  };
 }
 
 export default ChatsMainContentView;

--- a/client/src/views/message-fast-menu-view.ts
+++ b/client/src/views/message-fast-menu-view.ts
@@ -1,15 +1,53 @@
 import View from '../lib/view';
+import { $ } from '../utils/functions';
+import { RenderedPersonalMessage } from './chats-main-content-view';
+
+export type ReplyOrEdit = 'reply' | 'edit';
 
 class MessageFastMenuView extends View {
-  constructor($root: HTMLElement) {
+  message: RenderedPersonalMessage;
+
+  $message: HTMLLIElement;
+  $editButton: HTMLButtonElement;
+  $replyButton: HTMLButtonElement;
+  replyOrEdit: ReplyOrEdit;
+
+  constructor($root: HTMLElement, $message: HTMLLIElement, message: RenderedPersonalMessage, replyOrEdit: ReplyOrEdit) {
     if (!$root) {
       MessageFastMenuView.throwNoRootInTheDomError(`MessageFastMenuView`);
     }
     super($root);
+    this.message = message;
+    this.$editButton = $('button', 'fast-menu__edit-btn');
+    this.$replyButton = $('button', 'fast-menu__reply-btn');
+    this.$message = $message;
+    this.replyOrEdit = replyOrEdit;
   }
   async build(): Promise<void> {
-    this.$container.append('I am fast menu');
+    const $container = document.createDocumentFragment();
+    let $replyOrEditButton: HTMLButtonElement;
+
+    if (this.replyOrEdit === 'edit') {
+      $replyOrEditButton = this.$editButton;
+      this.$editButton.textContent = 'Edit';
+    } else {
+      $replyOrEditButton = this.$replyButton;
+      this.$replyButton.textContent = 'Reply';
+    }
+    $container.append($replyOrEditButton);
+
+    this.$container.append($container);
   }
+
+  bindShowEditForm = (handler: ($message: HTMLLIElement) => void): void => {
+    this.$editButton.onclick = () => {
+      handler(this.$message);
+    };
+  };
+
+  bindShowReply = (handler: () => void): void => {
+    this.$editButton.onclick = handler;
+  };
 }
 
 export default MessageFastMenuView;

--- a/server/src/controllers/chats.ts
+++ b/server/src/controllers/chats.ts
@@ -62,6 +62,7 @@ const getChatMessages: Handler = (req, res, next) => {
       { $and: [{ fromUserId: userTwoId }, { toUserId: userOneId }] }
     ],
   })
+    .populate('responsedToMessage')
     .then((messages) => {
       res.status(200).json({
         message: 'Fetched chat messages successfully.',

--- a/server/src/controllers/personal-messages.ts
+++ b/server/src/controllers/personal-messages.ts
@@ -1,6 +1,8 @@
 import { Handler } from 'express';
 import PersonalMessage from '../models/personal-message';
 import { DeletedRequestQuery } from '../routes/personal-messages';
+import { personalMessageDTO } from '../utils/dto';
+import { FetchedPersonalMessage } from '../utils/dto';
 
 const getPersonalMessages: Handler = (req, res, next) => {
   let docsCount = 0;
@@ -38,7 +40,8 @@ const createPersonalMessage: Handler = (req, res, next) => {
   const personalMessage = new PersonalMessage({
     fromUserId: req.body.fromUserId,
     toUserId: req.body.toUserId,
-    responsedMessageId: req.body.responsedMessageId,
+    responsedToMessageId: '63e9609f73a7e2949b55550a',
+    responsedToMessage: '63e9609f73a7e2949b55550a',
     message: req.body.message,
   });
 
@@ -93,7 +96,11 @@ const updatePersonalMessage: Handler = (req, res, next) => {
       return message.save();
     })
     .then((message) => {
-      res.status(200).json({ messageInfo: 'Message updated!', message });
+      message
+        .populate('responsedToMessage')
+        .then((message) => {
+          res.status(200).json({ messageInfo: 'Message updated!', message: personalMessageDTO(message as FetchedPersonalMessage) });
+        })
     })
     .catch((err) => {
       if (!err.statusCode) {

--- a/server/src/models/personal-message.ts
+++ b/server/src/models/personal-message.ts
@@ -1,12 +1,15 @@
 import mongoose, { HydratedDocument, Model, QueryWithHelpers, Types } from 'mongoose';
 import mongooseDelete from 'mongoose-delete';
+import { personalMessageDTO } from '../utils/dto';
+import { FetchedPersonalMessage } from '../utils/dto';
 
 export interface PersonalMessageDocument {
   fromUserId: Types.ObjectId;
   toUserId: Types.ObjectId;
-  responsedMessageId: Types.ObjectId;
+  responsedToMessageId: Types.ObjectId;
   date: Date;
   message: string;
+  responsedToMessage: PersonalMessageDocument | null;
 }
 
 interface PersonalMessageQueryHelpers {
@@ -36,7 +39,7 @@ export const personalMessageSchema = new Schema<
       type: Schema.Types.ObjectId,
       required: true,
     },
-    responsedMessageId: {
+    responsedToMessageId: {
       type: Schema.Types.ObjectId,
     },
     date: {
@@ -47,14 +50,15 @@ export const personalMessageSchema = new Schema<
       type: String,
       required: true,
     },
+    responsedToMessage: {
+      type: Types.ObjectId,
+      ref: 'PersonalMessage',
+      // get: function(this: PersonalMessageDocument | null) {
+      //   console.log(this);
+      //   return this ? this : undefined;
+      // } 
+    },
   },
-  // {
-  //   query: {
-  //     byDeleted(deleted: boolean) {
-  //       return this.find({ deleted });
-  //     },
-  //   },
-  // }
 );
 
 personalMessageSchema.query.byDeleted = function byDeleted(

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -86,23 +86,6 @@ const UserSchema = new Schema<UserDocument>(
   }
 );
 
-// UserSchema.virtual('chats', {
-//   ref: 'User',
-//   localField: 'chats',
-//   foreignField: '_id',
-// })
-//   .get(function (this: UserDocument) {
-//     const chat: ChatDocument = {
-//       userId: this.id.toString(),
-//       userName: this.name,
-//       availability: this.availability,
-//     };
-//     return chat;
-//   })
-//   .set(function () {
-//     this.set(this);
-//   });
-
 UserSchema.pre('save', function save(next) {
   const user = this as UserDocument;
   if (!user.isModified('password')) {

--- a/server/src/types/dto.ts
+++ b/server/src/types/dto.ts
@@ -16,9 +16,10 @@ export interface DTOUser extends DTOEntity {
 export interface DTOPersonalMessage extends DTOEntity {
   fromUserId: string;
   toUserId: string;
-  responseMessageId: string | null;
+  responsedToMessageId: string | null;
   date: Date;
   message: string;
+  responsedToMessage: DTOPersonalMessage | null;
 }
 
 export interface DTOChannelMessage extends DTOEntity {

--- a/server/src/utils/dto.ts
+++ b/server/src/utils/dto.ts
@@ -27,11 +27,14 @@ export const chatDTO = ({ _id, name, availability }: FetchedChat): DTOChat => ({
   availability,
 });
 
-export const personalMessageDTO = ({ _id, fromUserId, toUserId, responsedMessageId, date, message }: FetchedPersonalMessage): DTOPersonalMessage => ({
-  id: _id.toString(),
-  fromUserId: fromUserId.toString(),
-  toUserId: toUserId.toString(),
-  responseMessageId: responsedMessageId ? responsedMessageId.toString() : null,
-  date,
-  message,
-});
+export const personalMessageDTO = ({ _id, fromUserId, toUserId, responsedToMessageId, responsedToMessage, date, message }: FetchedPersonalMessage): DTOPersonalMessage => {
+  return {
+    id: _id.toString(),
+    fromUserId: fromUserId.toString(),
+    toUserId: toUserId.toString(),
+    responsedToMessageId: responsedToMessageId ? responsedToMessageId.toString() : null,
+    date,
+    message,
+    responsedToMessage: responsedToMessage ? personalMessageDTO(responsedToMessage as FetchedPersonalMessage) : null,
+  }
+};


### PR DESCRIPTION
Fast menu is displayed on chat message hover.

![image](https://user-images.githubusercontent.com/57676992/218487575-5955bf27-f54f-4faf-a1be-4584849f80c3.png)

Functional implemented: 
  - Clicking `edit` button adds a form allowing edit message on submit.
  - Hotkeys `escape` and `enter` to hide/submit form