### PR TITLE
Add delete personal message functionality

### DIFF
--- a/client/src/components/message-fast-menu.ts
+++ b/client/src/components/message-fast-menu.ts
@@ -1,11 +1,21 @@
 import Controller from '../lib/controller';
 import { appStore } from '../store/app-store';
 import { PersonalMessage } from '../types/entities';
+import { isElementOfCssClass } from '../utils/functions';
 import { RenderedPersonalMessage } from '../views/chats-main-content-view';
 import MessageFastMenuView, { ReplyOrEdit } from '../views/message-fast-menu-view';
 
 class MessageFastMenu extends Controller<MessageFastMenuView> {
+  private static _instance: MessageFastMenu;
+
+  static get instance(): MessageFastMenu {
+    return MessageFastMenu._instance;
+  }
+
   constructor($container: HTMLElement, $message: HTMLLIElement, message: RenderedPersonalMessage) {
+    if (MessageFastMenu.instance) {
+      MessageFastMenu.instance.destroy();
+    }
     const getReplyOrEdit = (message: RenderedPersonalMessage): ReplyOrEdit => {
       if (!appStore.user) {
         return 'edit';
@@ -17,21 +27,39 @@ class MessageFastMenu extends Controller<MessageFastMenuView> {
       }
     };
     super(new MessageFastMenuView($container, $message, message, getReplyOrEdit(message)));
+    MessageFastMenu._instance = this;
   }
 
   async init(): Promise<void> {
-    this.view.render();
-    this.view.bindShowEditForm(MessageFastMenu.showEditForm);
+    await this.view.render();
   }
 
   destroy(): void {
     this.view.getRootElement().innerHTML = '';
   }
 
-  static showEditForm = ($message: HTMLLIElement): void => {};
+  static onEditButtonClick = (event: MouseEvent): void => {
+    if (isElementOfCssClass(event.target, 'fast-menu__edit-btn')) {
+      MessageFastMenu.displayEditMessageForm(event);
+    }
+  };
 
-  static bindShowEditForm = (handler: ($message: HTMLLIElement) => void): void => {
-    MessageFastMenu.showEditForm = handler;
+  static onDeleteButtonClick = async (event: MouseEvent): Promise<void> => {
+    if (isElementOfCssClass(event.target, 'fast-menu__delete-btn')) {
+      await MessageFastMenu.displayDeleteConfirmModal(event);
+    }
+  };
+
+  static displayEditMessageForm = (event: MouseEvent): void => {};
+
+  static displayDeleteConfirmModal = async (event: MouseEvent): Promise<void> => {};
+
+  static bindDisplayEditMessageForm = (handler: (event: MouseEvent) => void): void => {
+    MessageFastMenu.displayEditMessageForm = handler;
+  };
+
+  static bindDisplayDeleteConfirmModal = (handler: (event: MouseEvent) => Promise<void>): void => {
+    MessageFastMenu.displayDeleteConfirmModal = handler;
   };
 }
 

--- a/client/src/views/message-fast-menu-view.ts
+++ b/client/src/views/message-fast-menu-view.ts
@@ -10,6 +10,7 @@ class MessageFastMenuView extends View {
   $message: HTMLLIElement;
   $editButton: HTMLButtonElement;
   $replyButton: HTMLButtonElement;
+  $deleteButton: HTMLButtonElement;
   replyOrEdit: ReplyOrEdit;
 
   constructor($root: HTMLElement, $message: HTMLLIElement, message: RenderedPersonalMessage, replyOrEdit: ReplyOrEdit) {
@@ -20,27 +21,34 @@ class MessageFastMenuView extends View {
     this.message = message;
     this.$editButton = $('button', 'fast-menu__edit-btn');
     this.$replyButton = $('button', 'fast-menu__reply-btn');
+    this.$deleteButton = $('button', 'fast-menu__delete-btn');
     this.$message = $message;
     this.replyOrEdit = replyOrEdit;
   }
   async build(): Promise<void> {
     const $container = document.createDocumentFragment();
-    let $replyOrEditButton: HTMLButtonElement;
 
     if (this.replyOrEdit === 'edit') {
-      $replyOrEditButton = this.$editButton;
+      $container.append(this.$editButton, this.$deleteButton);
       this.$editButton.textContent = 'Edit';
+      this.$deleteButton.textContent = 'Delete';
     } else {
-      $replyOrEditButton = this.$replyButton;
+      $container.append(this.$replyButton);
       this.$replyButton.textContent = 'Reply';
     }
-    $container.append($replyOrEditButton);
 
     this.$container.append($container);
   }
 
   bindShowEditForm = (handler: ($message: HTMLLIElement) => void): void => {
+    console.log('MessageFastMenuView.bindShowEditForm', this.$editButton, this.$message);
     this.$editButton.onclick = () => {
+      handler(this.$message);
+    };
+  };
+
+  bindDeleteMessage = (handler: ($message: HTMLLIElement) => void): void => {
+    this.$deleteButton.onclick = () => {
       handler(this.$message);
     };
   };

--- a/client/src/views/servers-bar-view.ts
+++ b/client/src/views/servers-bar-view.ts
@@ -33,7 +33,7 @@ class ServersBarView extends View {
   }
 
   displayServers(servers: Server[]): void {
-    //this.$serverList.innerHTML = '';
+    this.$serverList.innerHTML = '';
 
     const serversFake: Server[] = [
       {
@@ -48,16 +48,16 @@ class ServersBarView extends View {
       },
     ];
 
-    serversFake.forEach((server) => {
+    // serversFake.forEach((server) => {
+    //   const $item = this.createServerItem(server);
+    //   this.$serverList.append($item);
+    //   //this.onAppendServerItem($item, server);
+    // });
+    servers.forEach((server) => {
       const $item = this.createServerItem(server);
       this.$serverList.append($item);
-      //this.onAppendServerItem($item, server);
+      this.onAppendServerItem($item, server);
     });
-    //servers.forEach((server) => {
-    //  const $item = this.createServerItem(server);
-    //  this.$serverList.append($item);
-    //  this.onAppendServerItem($item, server);
-    //});
 
     this.$serverList.append(this.$addServerButton);
     this.bindShowModal();
@@ -75,7 +75,7 @@ class ServersBarView extends View {
         // image: 'https://source.boringavatars.com',
       };
 
-      // handler(server);
+      handler(server);
     });
   }
 
@@ -108,7 +108,7 @@ class ServersBarView extends View {
     $itemName.textContent = `${name}`;
 
     if (image) {
-      $itemImg.src = upload.default;
+      $itemImg.src = `data:image/png;base64, ${image}`;
     }
     $item.append($itemImg, $itemName);
 

--- a/client/src/views/servers-sidebar-view.ts
+++ b/client/src/views/servers-sidebar-view.ts
@@ -51,17 +51,17 @@ class ServersSideBarView extends View {
     //this.$serverList.innerHTML = '';
 
     const channelsFake: Channel[] = [
-      { 
+      {
         id: 'efef',
         channelId: '12',
-        channelName: 'RS'
+        channelName: 'RS',
       },
       {
         id: 'efef',
         channelId: '45',
-        channelName: 'SCSS'
-      }
-    ]
+        channelName: 'SCSS',
+      },
+    ];
 
     channelsFake.forEach((channel) => {
       const $item = this.createServerItem(channel);
@@ -137,7 +137,7 @@ class ServersSideBarView extends View {
     const $itemName = $('div', 'servers-sidebar__name');
     $itemName.textContent = `${channelName}`;
 
-    $item.append($itemIcon, $itemName)
+    $item.append($itemIcon, $itemName);
 
     this.bindChatItemClick($item);
     return $item;


### PR DESCRIPTION
Personal message are now deletable.

Clicking `delete` button of fast menu invokes a confirm dialog to cancel or submit delete operation.

![image](https://user-images.githubusercontent.com/57676992/218589305-7dc0945c-ea55-4146-acbe-fee445fe893a.png)
