### PR TITLE
Error handling for auth views

### DIFF
--- a/client/src/components/error-modal.ts
+++ b/client/src/components/error-modal.ts
@@ -1,0 +1,17 @@
+import Controller from '../lib/controller';
+import ErrorModalView from '../views/error-modal-view';
+import ModalComponent from './modal';
+
+class ErrorModalComponent extends Controller<ErrorModalView> {
+  constructor() {
+    new ModalComponent().init();
+    super(new ErrorModalView());
+  }
+
+  async init(): Promise<void> {
+    this.view.render();
+    this.view.show();
+  }
+}
+
+export default ErrorModalComponent;

--- a/client/src/components/modal.ts
+++ b/client/src/components/modal.ts
@@ -7,6 +7,7 @@ class ModalComponent extends Controller<ModalView> {
   }
 
   async init(): Promise<void> {
+    console.log('modal init');
     this.view.render();
   }
 }

--- a/client/src/components/sign-up.ts
+++ b/client/src/components/sign-up.ts
@@ -1,4 +1,5 @@
 import Controller from '../lib/controller';
+import Router, { RouteControllers } from '../lib/router';
 import { appStore } from '../store/app-store';
 import { Dispatch } from '../types/types';
 import SignUpView from '../views/sign-up-view';
@@ -31,7 +32,19 @@ class SignUpComponent extends Controller<SignUpView> {
       typeof password === 'string' &&
       typeof name === 'string'
     ) {
-      await appStore.register(email, password, name);
+      await appStore.register(
+        { email, password, name },
+        () => {
+          Router.push(RouteControllers.Chats);
+        },
+        (error) => {
+          if ('errors' in error.data) {
+            this.view.displayError(error.data.errors.map(({ msg }) => msg));
+          } else if ('message' in error.data) {
+            this.view.displayError([error.data.message]);
+          }
+        }
+      );
     }
   };
 }

--- a/client/src/develop/data.ts
+++ b/client/src/develop/data.ts
@@ -4,7 +4,7 @@ import { RenderedPersonalMessage } from '../views/chats-main-content-view';
 
 export const users: User[] = [
   {
-    id: '63dd3d9da1340145e9b74055',
+    id: '63eec17d4064de726f4584da',
     name: 'Hlib Hodovaniuk',
     password: '1111333',
     email: 'gleb.godovanyuk@gmail.com',

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -18,7 +18,7 @@ bindGlobalSocketEvents();
 })();
 
 async function main() {
-  await http.test();
+  // await http.test();
   await App.run();
   socket.emit('run');
   ChatsScreen.bindRouteChanged();

--- a/client/src/lib/http.ts
+++ b/client/src/lib/http.ts
@@ -1,13 +1,27 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
 import { API_URL } from '../constants';
 import socket from './socket';
+import { IExpressError } from '../types/http-errors';
 
-enum ErrorStatusCode {
+export enum ErrorStatusCode {
   Unauthorized = 401,
   Forbidden = 403,
+  NotFound = 404,
   TooManyRequests = 429,
   InternalServerError = 500,
 }
+
+export const isExpressError = <T = unknown>(error: IExpressError<T> | Error): error is IExpressError<T> => {
+  return 'data' in error;
+};
+
+export const handleError = <T>(error: IExpressError<T> | Error, callback: (error: IExpressError<T>) => void) => {
+  if (isExpressError<T>(error)) {
+    callback(error);
+  } else {
+    console.error(error);
+  }
+};
 
 const headers: Readonly<Record<string, string | boolean>> = {
   Accept: 'application/json',
@@ -51,7 +65,7 @@ class Http {
 
     http.interceptors.request.use((config) => {
       if (config.url !== '/test' && !this.connected) {
-        throw Error('NO CONNECTION!');
+        // throw Error('NO CONNECTION!');
       }
       return config;
     });

--- a/client/src/types/http-errors.ts
+++ b/client/src/types/http-errors.ts
@@ -1,0 +1,18 @@
+export interface IExpressError<T = unknown> {
+  data: T;
+  status: number;
+}
+
+export type ErrorCallback<T = unknown> = (error: Error | IExpressError<T>) => void;
+
+export type LoginError = IExpressError<LoginErrorData>;
+
+export type RegisterError = IExpressError<RegisterErrorData | LoginErrorData>;
+
+export interface LoginErrorData {
+  message: string;
+}
+
+export interface RegisterErrorData {
+  errors: { value: string; msg: string; param: string; location: string }[];
+}

--- a/client/src/views/error-modal-view.ts
+++ b/client/src/views/error-modal-view.ts
@@ -1,0 +1,25 @@
+import View from '../lib/view';
+import ModalView from './modal-view';
+
+class ErrorModalView extends View {
+  constructor() {
+    const $root = ModalView.getContainer();
+    if (!$root) {
+      ErrorModalView.throwNoRootInTheDomError('Error-Modal');
+    }
+    super($root);
+  }
+  build(): void {
+    this.$container.append('HEEEEEEEEEEEEEEEEHEHEH');
+  }
+
+  show(): void {
+    ModalView.show();
+  }
+
+  hide(): void {
+    ModalView.hide();
+  }
+}
+
+export default ErrorModalView;

--- a/client/src/views/sign-in-view.ts
+++ b/client/src/views/sign-in-view.ts
@@ -8,6 +8,7 @@ class SignInView extends View {
 
   $signUpButton: HTMLButtonElement;
   $form: HTMLFormElement;
+  $errorContainer: HTMLDivElement;
 
   constructor() {
     const $root = document.getElementById('root');
@@ -17,6 +18,7 @@ class SignInView extends View {
     super($root);
     this.$form = $('form', 'sign-in__form');
     this.$signUpButton = $('button', 'btn btn-auth');
+    this.$errorContainer = $('div', 'sign-in__error-container');
   }
 
   build(): void {
@@ -43,7 +45,7 @@ class SignInView extends View {
     this.$signUpButton.textContent = 'Register';
     $btnSignUpBox.append($text, this.$signUpButton);
 
-    $box.append($title, this.$form, $btnSignUpBox);
+    $box.append($title, this.$errorContainer, this.$form, $btnSignUpBox);
     $container.append($box);
     this.$container.append($container);
   }
@@ -57,6 +59,11 @@ class SignInView extends View {
       event.preventDefault();
       handler(new FormData(this.$form));
     });
+  }
+
+  displayError(message: string) {
+    this.$errorContainer.innerHTML = '';
+    this.$errorContainer.textContent = message;
   }
 }
 

--- a/client/src/views/sign-up-view.ts
+++ b/client/src/views/sign-up-view.ts
@@ -8,6 +8,7 @@ class SignUpView extends View {
 
   $signInButton: HTMLButtonElement;
   $form: HTMLFormElement;
+  $errorContainer: HTMLDivElement;
 
   constructor() {
     const $root = document.getElementById('root');
@@ -17,6 +18,7 @@ class SignUpView extends View {
     super($root);
     this.$form = $('form', 'sign-up__form');
     this.$signInButton = $('button', 'btn btn-auth');
+    this.$errorContainer = $('div', 'sign-up__error-container');
   }
   build(): void {
     const $container = $('div', 'sign-up');
@@ -43,7 +45,7 @@ class SignUpView extends View {
 
     this.$signInButton.textContent = 'Already have an account?';
 
-    $box.append($title, this.$form, this.$signInButton);
+    $box.append($title, this.$errorContainer, this.$form, this.$signInButton);
     $container.append($box);
 
     this.$container.append($container);
@@ -60,6 +62,11 @@ class SignUpView extends View {
       event.preventDefault();
       handler(new FormData(this.$form));
     });
+  }
+
+  displayError(errors: string[]) {
+    this.$errorContainer.innerHTML = '';
+    this.$errorContainer.innerHTML = errors.join('<br/>');
   }
 }
 

--- a/server/src/controllers/chats.ts
+++ b/server/src/controllers/chats.ts
@@ -14,6 +14,8 @@ const getChats: Handler = (req, res, next) => {
     .then((user) => {
       if (handleDocumentNotFound(user)) {
         res.status(200).json({ chats: (user.chats || []).map((c) => chatDTO(c as FetchedChat))})
+      } else {
+        res.status(200).json({ chats: []});
       }
     })
 };

--- a/server/src/controllers/users.ts
+++ b/server/src/controllers/users.ts
@@ -39,7 +39,6 @@ const login = async (req: TypedRequest, res: Response, next: NextFunction): Prom
   passport.authenticate('local', (err: Error, user: UserDocument, info: IVerifyOptions) => {
     if (err) {
       return next(err);
-      return;
     }
     if (!user) {
       res.status(401).json({ message: info.message });
@@ -71,6 +70,9 @@ const login = async (req: TypedRequest, res: Response, next: NextFunction): Prom
 };
 
 const logout = (req: TypedRequest, res: Response, next: NextFunction): void => {
+  if (!req.user) {
+    res.send(200).end();
+  }
   const { id } = req.user as HydratedDocument<UserDocument>;
   req.logout((err) => {
     if (err) {
@@ -112,7 +114,6 @@ const register = async (req: Request, res: Response, next: NextFunction): Promis
     email: req.body.email,
     password: req.body.password,
     name: req.body.name,
-    phone: req.body.phone,
   });
 
   User.findOne({ email: req.body.email }, (err: NativeError, existingUser: UserDocument) => {
@@ -131,7 +132,7 @@ const register = async (req: Request, res: Response, next: NextFunction): Promis
         if (err) {
           return next(err);
         }
-        res.status(200).end();
+        res.status(200).json({ user: userDTO(user) });
       });
     });
   });

--- a/server/src/utils/functions.ts
+++ b/server/src/utils/functions.ts
@@ -28,5 +28,6 @@ export const handleDocumentNotFound = <T extends Document>(
   const error = Object.assign(new Error('Could not find user.'), {
     statusCode: 404,
   });
-  throw error;
+  console.log(error);
+  return false;
 };


### PR DESCRIPTION
Implemented error handling for sign-in and sign-up pages.

When password is too short.
![image](https://user-images.githubusercontent.com/57676992/219522669-53ce9767-583c-4255-8add-e142cb064030.png)

When account with email already exists
![image](https://user-images.githubusercontent.com/57676992/219522771-ba84efc6-09b9-4456-a7e6-7405101012a7.png)
